### PR TITLE
fix: Issues with layerClass and v8 runtime

### DIFF
--- a/Source/PreviewView.swift
+++ b/Source/PreviewView.swift
@@ -37,9 +37,9 @@ import AVFoundation
     case resizeAspectFill
 }
 
-@objcMembers open class PreviewView: UIView {
+@objc open class PreviewView: UIView {
     
-    public var gravity: SwiftyCamVideoGravity = .resizeAspect {
+    @objc public var gravity: SwiftyCamVideoGravity = .resizeAspect {
         didSet {
             let previewlayer = layer as! AVCaptureVideoPreviewLayer
             switch gravity {
@@ -59,11 +59,11 @@ import AVFoundation
         self.backgroundColor = UIColor.black
     }
     
-    required public init?(coder aDecoder: NSCoder) {
+    @objc required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
-	public var videoPreviewLayer: AVCaptureVideoPreviewLayer {
+	@objc public var videoPreviewLayer: AVCaptureVideoPreviewLayer {
         let previewlayer = layer as! AVCaptureVideoPreviewLayer
         switch gravity {
         case .resize:
@@ -76,7 +76,7 @@ import AVFoundation
 		return previewlayer
 	}
 	
-	public var session: AVCaptureSession? {
+	@objc public var session: AVCaptureSession? {
 		get {
 			return videoPreviewLayer.session
 		}
@@ -87,7 +87,7 @@ import AVFoundation
 	
 	// MARK: UIView
 	
-	@objc override open class var layerClass : AnyClass {
+	override open class var layerClass : AnyClass {
 		return AVCaptureVideoPreviewLayer.self
 	}
 }


### PR DESCRIPTION
I don't know the reason for this but the v8 runtime blows up when layerClass is exposed to objective-c.  It causes the MetadataBuilder::RegisterStaticMethods function to fail.

I tested this without exposing layerClass to objective-c and everything works fine.  This is key to fixing https://github.com/nstudio/nativescript-plugins/issues/12