### PR TITLE
Allow compilation with xcode 13 and 12

### DIFF
--- a/Source/SwiftyCamViewController.swift
+++ b/Source/SwiftyCamViewController.swift
@@ -1068,7 +1068,13 @@ import AVFoundation
         
         @available(iOS 11.0, *)
         func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photo: AVCapturePhoto, error: Error?) {
-            if let cgImage = photo.cgImageRepresentation()?.takeUnretainedValue() {
+            let cgImage: CGImage?
+            #if compiler(>=5.5)
+            cgImage = photo.cgImageRepresentation()
+            #else
+            cgImage = photo.cgImageRepresentation()?.takeUnretainedValue()
+            #endif
+            if let cgImage = cgImage {
                 var image: UIImage
                 let rectToCrop = self.controller.calculateAspectRatioCrop(cgImage.width, cgImage.height)
                 if(rectToCrop != nil){


### PR DESCRIPTION
Currently SwiftyCam will not compile when using xcode 13 due to the return type of cgImageRepresentation changing in iOS15, reference https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-15-release-notes

Fixes the issue reported here: https://github.com/nstudio/nativescript-camera-plus/issues/166

